### PR TITLE
Add link to barebones Relay application on Rails server

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Awesome resources for [Relay](https://github.com/facebook/relay), based on the [
 - [Relay Starter Kit](https://github.com/relayjs/relay-starter-kit) - An app that it already set up with a basic setup. Just clone and tweak to suit your needs!
 - [Simple Relay Starter](https://github.com/mhart/simple-relay-starter) - A Browserify version of the [Relay Starter Kit](https://github.com/relayjs/relay-starter-kit).
 - [Isomorphic Material Relay Starter Kit](https://github.com/codefoundries/isomorphic-material-relay-starter-kit) - Isomorphic Relay starter kit with examples. Uses Material-UI, Webpack, hot reload, Helmet, JWT. Utilizes Facebook Data Loader for persistence into in-memory structures and Cassandra.
+- [Rails Relay Starter Kit](https://github.com/nethsix/relay-on-rails) - A barebones starter kit for Relay application on Rails server. Just clone and tweak!
 
 # Relay-Specific Server Support
 ## Go


### PR DESCRIPTION
Comes with:
- rake task to update GraphQL JSON schema (used by babel-relay-plugin)
  when server-side GraphQL schema is update.
- Link to article explaining the entire setup for learning purposes
